### PR TITLE
feat(api): change endpoint path

### DIFF
--- a/crates/pr-tracker-api/src/lib.rs
+++ b/crates/pr-tracker-api/src/lib.rs
@@ -18,7 +18,7 @@ pub fn app() -> rocket::fairing::AdHoc {
 #[database("data")]
 struct Data(sqlx::Pool<sqlx::Postgres>);
 
-#[rocket::get("/landed/github/<pr>")]
+#[rocket::get("/api/v1/<pr>")]
 async fn landed(
     mut db: Connection<Data>,
     pr: u32,

--- a/crates/pr-tracker-api/tests/test.rs
+++ b/crates/pr-tracker-api/tests/test.rs
@@ -22,7 +22,7 @@ async fn pr_not_found() {
             let client = rocket::local::asynchronous::Client::tracked(ctx.rocket())
                 .await
                 .unwrap();
-            let response = client.get("/landed/github/2134").dispatch().await;
+            let response = client.get("/api/v1/2134").dispatch().await;
             assert_eq!(response.status(), rocket::http::Status::NotFound);
             assert_eq!(
                 response.into_string().await,
@@ -52,7 +52,7 @@ async fn pr_not_landed() {
                 .await
                 .unwrap();
 
-            let response = client.get("/landed/github/123").dispatch().await;
+            let response = client.get("/api/v1/123").dispatch().await;
             assert_eq!(response.status(), rocket::http::Status::Ok);
 
             assert_eq!(
@@ -95,7 +95,7 @@ async fn pr_landed() {
                 .await
                 .unwrap();
 
-            let response = client.get("/landed/github/2134").dispatch().await;
+            let response = client.get("/api/v1/2134").dispatch().await;
             assert_eq!(response.status(), rocket::http::Status::Ok);
 
             assert_eq!(


### PR DESCRIPTION
BREAKING CHANGE: the endpoint is now /api/v1/<pr>

closes #10 