### PR TITLE
test: don't test on darwin

### DIFF
--- a/.github/workflows/check.yml
+++ b/.github/workflows/check.yml
@@ -5,10 +5,7 @@ on:
 
 jobs:
   check:
-    strategy:
-      matrix:
-        runner: [ubuntu-latest, macos-latest]
-    runs-on: ${{ matrix.runner }}
+    runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v4
       - uses: DeterminateSystems/nix-installer-action@main

--- a/flake.nix
+++ b/flake.nix
@@ -38,9 +38,7 @@
         })
       ];
 
-      # NixOS tests don't "just work" on Darwin. See
-      # https://github.com/NixOS/nixpkgs/issues/254552 for details.
-      nixosTests = optionalAttrs (!pkgs.stdenv.isDarwin) {
+      nixosTests = {
         api-module = import ./nixos-tests/api.nix {
           modules = systemAgnosticOutputs.nixosModules;
           inherit pkgs;

--- a/packages/default.nix
+++ b/packages/default.nix
@@ -12,12 +12,7 @@
     readDir
     ;
 
-  buildInputs =
-    if pkgs.stdenv.isDarwin
-    then with pkgs; [darwin.apple_sdk.frameworks.SystemConfiguration]
-    else if pkgs.stdenv.isLinux
-    then with pkgs; [pkg-config openssl]
-    else throw "unsupported";
+  buildInputs = with pkgs; [pkg-config openssl];
 
   nativeCheckInputs = with pkgs; [postgresql clippy];
 


### PR DESCRIPTION
This is causing us a headache. We only plan to deploy this to a Linux
box, so there's no need to test against darwin.

Co-authored-by: Shahar "Dawn" Or <mightyiampresence@gmail.com>
