### PR TITLE
build(flake): nicer merging of checks attrset

### DIFF
--- a/flake.nix
+++ b/flake.nix
@@ -29,6 +29,8 @@
       optionalAttrs
       ;
 
+    flattenTree = import ./flattenTree.nix;
+
     forEachDefaultSystem = system: let
       pkgs = nixpkgs.legacyPackages.${system};
       craneLib = crane.lib.${system};
@@ -65,13 +67,11 @@
         SQLX_OFFLINE = "true";
       };
 
-      checks =
-        packages
-        // nixosTests
-        // {
-          inherit clippyCheck;
-          formatting = treefmtEval.config.build.check self;
-        };
+      checks = flattenTree {
+        inherit packages nixosTests;
+        clippy = clippyCheck;
+        formatting = treefmtEval.config.build.check self;
+      };
 
       formatter = treefmtEval.config.build.wrapper;
     };

--- a/flattenTree.nix
+++ b/flattenTree.nix
@@ -1,0 +1,29 @@
+# TODO: consider contributing a recursive version of this upstream to
+# flake-utils. See https://github.com/numtide/flake-utils/issues/112.
+tree: let
+  op = sum: path: val: let
+    pathStr = builtins.concatStringsSep "/" path;
+  in
+    if (builtins.typeOf val) != "set"
+    then
+      # ignore that value
+      # builtins.trace "${pathStr} is not of type set"
+      sum
+    else if val ? type && val.type == "derivation"
+    then
+      # builtins.trace "${pathStr} is a derivation"
+      # we used to use the derivation outPath as the key, but that crashes Nix
+      # so fallback on constructing a static key
+      (sum
+        // {
+          "${pathStr}" = val;
+        })
+    else (recurse sum path val);
+
+  recurse = sum: path: val:
+    builtins.foldl'
+    (sum: key: op sum (path ++ [key]) val.${key})
+    sum
+    (builtins.attrNames val);
+in
+  recurse {} [] tree


### PR DESCRIPTION
This allows the sub-attrsets to have the same key names, and we'll
ensure they're unique when merging.

Co-authored-by: Roland Fredenhagen <dev@modprog.de>
Co-authored-by: Shahar "Dawn" Or <mightyiampresence@gmail.com>
