### PR TITLE
chore(fetcher): anyhow backtrace feature

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -65,6 +65,9 @@ name = "anyhow"
 version = "1.0.75"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "a4668cab20f66d8d020e1fbc0ebe47217433c1b6c8f2040faf858554e394ace6"
+dependencies = [
+ "backtrace",
+]
 
 [[package]]
 name = "arc-swap"

--- a/crates/fetcher/Cargo.toml
+++ b/crates/fetcher/Cargo.toml
@@ -6,7 +6,7 @@ edition = "2021"
 # See more keys and their definitions at https://doc.rust-lang.org/cargo/reference/manifest.html
 
 [dependencies]
-anyhow = "1.0.75"
+anyhow = { version = "1.0.75", features = ["backtrace"] }
 camino = "1.1.6"
 chrono = { version = "0.4.31", features = ["serde"] }
 derive_more.workspace = true


### PR DESCRIPTION
For useful errors printed in the future by the executable.

Co-authored-by: Jeremy Fleischman <jeremyfleischman@gmail.com>
