### PR TITLE
fix: ensure the cache directory exists

### DIFF
--- a/modules/fetcher/package.nix
+++ b/modules/fetcher/package.nix
@@ -21,6 +21,8 @@
     ;
 
   cfg = config.services.pr-tracker-fetcher;
+  defaultCacheDirName = "pr-tracker-fetcher";
+  defaultCacheDir = "/var/cache/${defaultCacheDirName}";
 in {
   options.services.pr-tracker-fetcher.enable = mkEnableOption "the pr tracker fetcher";
   options.services.pr-tracker-fetcher.package = mkPackageOption pr-tracker.packages.${pkgs.system} "fetcher" {};
@@ -64,7 +66,7 @@ in {
   options.services.pr-tracker-fetcher.cacheDir = mkOption {
     type = types.path;
     description = "Cache directory";
-    default = "/var/cache/pr-tracker-fetcher";
+    default = defaultCacheDir;
   };
 
   options.services.pr-tracker-fetcher.repo.owner = mkOption {
@@ -115,5 +117,6 @@ in {
     systemd.services.pr-tracker-fetcher.serviceConfig.Group = cfg.group;
     systemd.services.pr-tracker-fetcher.serviceConfig.Type = "oneshot";
     systemd.services.pr-tracker-fetcher.serviceConfig.Restart = "on-failure";
+    systemd.services.pr-tracker-fetcher.serviceConfig.CacheDir = optional (cfg.cacheDir == defaultCacheDir) defaultCacheDirName;
   };
 }


### PR DESCRIPTION
Without this, we're seeing the fetcher crash on startup:

    Jan 31 11:03:24 clark systemd[1]: Starting pr-tracker-fetcher...
    Jan 31 11:03:25 clark pr-tracker-fetcher-start[324252]: Error: git Command { std: GIT_AUTHOR_EMAIL="pr-tracker@example.com" GIT_AUTHOR_NAME="PR Tracker" GIT_COMMITTER_EMAIL="pr-tracker@example.com" GIT_COMMITTER_NAME="PR Tracker" GIT_CONFIG_GLOBAL="/dev/null" GIT_CONFIG_SYSTEM="/dev/null" "git" "clone" "https://github>
    Jan 31 11:03:25 clark pr-tracker-fetcher-start[324252]:  exited with Some(128)
    Jan 31 11:03:25 clark pr-tracker-fetcher-start[324252]:  stderr: fatal: could not create leading directories of '/var/cache/pr-tracker-fetcher/repos/github.com/NixOS/nixpkgs'
    Jan 31 11:03:25 clark systemd[1]: pr-tracker-fetcher.service: Main process exited, code=exited, status=1/FAILURE
    Jan 31 11:03:25 clark systemd[1]: pr-tracker-fetcher.service: Failed with result 'exit-code'.

I patterned this off of the minidlna service in nixpkgs: https://github.com/NixOS/nixpkgs/blob/3a73796bf2edb1dc026257da827678117ee7af57/nixos/modules/services/networking/minidlna.nix

This `CacheDirectory` setting is documented here in the [systemd docs], it creates a directory with the appropriate permissions underneath `/var/cache`.

[systemd docs]: https://www.freedesktop.org/software/systemd/man/latest/systemd.exec.html#RuntimeDirectory=