### PR TITLE
feat(api): takes only port and database url env vars

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2489,11 +2489,13 @@ name = "pr-tracker-api"
 version = "1.0.0"
 dependencies = [
  "camino",
+ "confique",
  "db-context",
  "pr-tracker-store",
  "rocket",
  "rocket_db_pools",
  "sd-notify",
+ "serde",
  "sqlx",
  "tempfile",
  "thiserror",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -9,9 +9,11 @@ license = "AGPL-3.0-only"
 repository = "https://github.com/molybdenumsoftware/pr-tracker"
 
 [workspace.dependencies]
+confique = { version = "0.2.5", default-features = false }
 db-context = { version = "1.0.0", path = "crates/db-context" }
 derive_more = { version = "1.0.0-beta.6", features = ["from", "deref"] }
 pr-tracker-store = { version = "1.0.0", path = "crates/store" }
+serde = "1.0.193"
 tempfile = "3.8.1"
 thiserror = "1.0.56"
 util = { version = "1.0.0", path = "crates/util" }

--- a/crates/api/Cargo.toml
+++ b/crates/api/Cargo.toml
@@ -10,9 +10,11 @@ repository.workspace = true
 
 [dependencies]
 camino = "1.1.6"
+confique.workspace = true
 pr-tracker-store.workspace = true
 rocket = { version = "0.5.0", features = ["json"] }
 rocket_db_pools = { version = "0.1.0", features = ["sqlx_postgres"] }
+serde.workspace = true
 sqlx = { version = "0.7", default-features = false, features = ["macros", "migrate"] }
 thiserror.workspace = true
 util.workspace = true

--- a/crates/api/src/main.rs
+++ b/crates/api/src/main.rs
@@ -1,11 +1,35 @@
 #![warn(clippy::pedantic)]
 // required because rocket::launch, remove if clippy permits.
 #![allow(clippy::no_effect_underscore_binding)]
+#![allow(non_snake_case, clippy::struct_field_names)]
 
+use confique::Config;
 use pr_tracker_api::app;
-use rocket::launch;
+use rocket::{figment::Figment, launch};
+
+#[derive(Debug, Config)]
+struct Environment {
+    #[config(env = "PR_TRACKER_API_DATABASE_URL")]
+    PR_TRACKER_API_DATABASE_URL: String,
+    #[config(env = "PR_TRACKER_API_PORT")]
+    PR_TRACKER_API_PORT: u16,
+}
 
 #[launch]
 fn rocket() -> _ {
-    rocket::build().attach(app())
+    let config = Environment::builder()
+        .env()
+        .load()
+        .expect("loading configuration from environment");
+
+    let Environment {
+        PR_TRACKER_API_DATABASE_URL: db_url,
+        PR_TRACKER_API_PORT: port,
+    } = config;
+
+    let figment = Figment::from(rocket::Config::default())
+        .merge(("port", port))
+        .merge(("databases.data.url", db_url));
+
+    rocket::custom(figment).attach(app())
 }

--- a/crates/fetcher/Cargo.toml
+++ b/crates/fetcher/Cargo.toml
@@ -18,13 +18,13 @@ log = "0.4"
 env_logger = "0.10.1"
 pr-tracker-store.workspace = true
 reqwest = { version = "0.11.22", default-features = false, features = ["rustls"] }
-serde = "1.0.193"
+serde.workspace = true
 tokio = { version = "1.34.0", features = ["process", "macros", "rt", "rt-multi-thread"] }
 util.workspace = true
 wildmatch = { version = "2.3.0", features = ["serde"] }
 sqlx-core = "0.7.3"
 serde_json = "1.0.111"
-confique = { version = "0.2.5", default-features = false }
+confique.workspace = true
 
 [dev-dependencies]
 db-context.workspace = true

--- a/modules/api/package.nix
+++ b/modules/api/package.nix
@@ -67,8 +67,8 @@ in {
     };
 
     systemd.services.pr-tracker-api.description = "pr-tracker-api";
-    systemd.services.pr-tracker-api.environment.ROCKET_DATABASES = "{data={url=${cfg.databaseUrl}}}";
-    systemd.services.pr-tracker-api.environment.ROCKET_PORT = toString cfg.port;
+    systemd.services.pr-tracker-api.environment.PR_TRACKER_API_DATABASE_URL = cfg.databaseUrl;
+    systemd.services.pr-tracker-api.environment.PR_TRACKER_API_PORT = toString cfg.port;
 
     systemd.services.pr-tracker-api.wantedBy = ["multi-user.target"];
     systemd.services.pr-tracker-api.after = ["network.target"] ++ optional cfg.localDb "postgresql.service";


### PR DESCRIPTION
closes #86

Co-authored-by: Shahar "Dawn" Or <mightyiampresence@gmail.com>

BREAKING CHANGE: no longer takes arbitrary ROCKET_* environment variables. Takes only PR_TRACKER_API_PORT and
PR_TRACKER_API_DATABASE_URL variables.