### PR TITLE
fix(flake): nixos modules do not use systemd environment

### DIFF
--- a/modules/fetcher/package.nix
+++ b/modules/fetcher/package.nix
@@ -13,6 +13,7 @@
   inherit
     (lib)
     attrsToList
+    escapeShellArg
     escapeURL
     getExe
     mkEnableOption
@@ -113,30 +114,32 @@ in {
     systemd.timers.pr-tracker-fetcher.wantedBy = ["timers.target"];
 
     systemd.services.pr-tracker-fetcher.description = "pr-tracker-fetcher";
-    systemd.services.pr-tracker-fetcher.environment.PR_TRACKER_FETCHER_DATABASE_URL = let
-      pairs = map (param: "${escapeURL param.name}=${escapeURL param.value}") (attrsToList cfg.dbUrlParams);
-      params = concatStringsSep "&" pairs;
-    in "postgresql://?${params}";
-    systemd.services.pr-tracker-fetcher.environment.PR_TRACKER_FETCHER_GITHUB_REPO_OWNER = cfg.repo.owner;
-    systemd.services.pr-tracker-fetcher.environment.PR_TRACKER_FETCHER_GITHUB_REPO_NAME = cfg.repo.name;
-    systemd.services.pr-tracker-fetcher.environment.PR_TRACKER_FETCHER_BRANCH_PATTERNS = toJSON cfg.branchPatterns;
     systemd.services.pr-tracker-fetcher.after = ["network.target"] ++ optional cfg.localDb "postgresql.service";
     systemd.services.pr-tracker-fetcher.requires = optional cfg.localDb "postgresql.service";
     systemd.services.pr-tracker-fetcher.script = let
+      databaseUrl = let
+        pairs = map (param: "${escapeURL param.name}=${escapeURL param.value}") (attrsToList cfg.dbUrlParams);
+        params = concatStringsSep "&" pairs;
+      in "postgresql://?${params}";
+
       passwordFile = optional (cfg ? "dbPasswordFile") ''
         PASSWORD=$(${getExe urlencode} --encode-set component < ${cfg.dbPasswordFile})
         PR_TRACKER_FETCHER_DATABASE_URL="$PR_TRACKER_FETCHER_DATABASE_URL&password=$PASSWORD"
       '';
     in
       concatStringsSep "\n" (
-        passwordFile
-        ++ [
+        [
+          "export PR_TRACKER_FETCHER_DATABASE_URL=${escapeShellArg databaseUrl}"
+          "export PR_TRACKER_FETCHER_GITHUB_REPO_OWNER=${escapeShellArg cfg.repo.owner}"
+          "export PR_TRACKER_FETCHER_GITHUB_REPO_NAME=${escapeShellArg cfg.repo.name}"
+          "export PR_TRACKER_FETCHER_BRANCH_PATTERNS=${escapeShellArg (toJSON cfg.branchPatterns)}"
           "export PR_TRACKER_FETCHER_GITHUB_TOKEN=$(< ${cfg.githubApiTokenFile})"
           # CACHE_DIRECTORY is set by systemd based on the CacheDirectory setting.
           # See https://www.freedesktop.org/software/systemd/man/latest/systemd.exec.html#RuntimeDirectory=
           "export PR_TRACKER_FETCHER_CACHE_DIR=$CACHE_DIRECTORY"
-          "exec ${getExe cfg.package}"
         ]
+        ++ passwordFile
+        ++ ["exec ${getExe cfg.package}"]
       );
 
     systemd.services.pr-tracker-fetcher.serviceConfig.User = cfg.user;


### PR DESCRIPTION
Turns out that systemd "supports" expansion in environment variables.
This might confuse our users. It did cost us an hour or so.

closes #121

BREAKING CHANGE: if you were using systemd's "unit specifiers" in
environment variables, that won't work any more.

Co-authored-by: Jeremy Fleischman <jeremyfleischman@gmail.com>
