### PR TITLE
build: single check run on push to main

### DIFF
--- a/.github/workflows/check.yml
+++ b/.github/workflows/check.yml
@@ -1,7 +1,5 @@
 on:
   pull_request:
-  push:
-    branches: [main]
   workflow_call:
 
 jobs:


### PR DESCRIPTION
check workflow gets triggered on push to main
release workflow does, as well and it triggers check once
so that's twice.
this fixes that
