### PR TITLE
chore(deps): * as range for most direct dependencies

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -10,14 +10,14 @@ license = "AGPL-3.0-only"
 repository = "https://github.com/molybdenumsoftware/pr-tracker"
 
 [workspace.dependencies]
-camino = { version = "1.1.6", features = ["serde1"] }
-confique = { version = "0.2.5", default-features = false }
+camino = { version = "*", features = ["serde1"] }
+confique = { version = "*", default-features = false }
 db-context.path = "crates/db-context"
 derive_more = { version = "1.0.0-beta.6", features = ["from", "deref"] }
 pr-tracker-store.path = "crates/store"
-serde = "1.0.193"
-tempfile = "3.8.1"
-thiserror = "1.0.56"
+serde = "*"
+tempfile = "*"
+thiserror = "*"
 util.path = "crates/util"
 
 [profile.release]

--- a/crates/api/Cargo.toml
+++ b/crates/api/Cargo.toml
@@ -11,20 +11,20 @@ publish = false
 
 [dependencies]
 pr-tracker-api-config = { path = "../api-config" }
-camino = "1.1.6"
+camino = "*"
 confique.workspace = true
 pr-tracker-store.workspace = true
-rocket = { version = "0.5.0", features = ["json"] }
-rocket_db_pools = { version = "0.1.0", features = ["sqlx_postgres"] }
+rocket = { version = "*", features = ["json"] }
+rocket_db_pools = { version = "*", features = ["sqlx_postgres"] }
 serde.workspace = true
-sqlx = { version = "0.7", default-features = false, features = ["macros", "migrate"] }
+sqlx = { version = "*", default-features = false, features = ["macros", "migrate"] }
 thiserror.workspace = true
 util.workspace = true
 
 [target.'cfg(target_family = "unix")'.dependencies]
-sd-notify = "0.4.1"
+sd-notify = "*"
 
 [dev-dependencies]
 db-context.workspace = true
 tempfile.workspace = true
-tokio = "1.34.0"
+tokio = "*"

--- a/crates/db-context/Cargo.toml
+++ b/crates/db-context/Cargo.toml
@@ -10,8 +10,8 @@ publish = false
 # See more keys and their definitions at https://doc.rust-lang.org/cargo/reference/manifest.html
 
 [dependencies]
-camino = "1.1.6"
-futures = "0.3.29"
-sqlx = { version = "0.7.3", features = ["postgres", "runtime-tokio"] }
-tempfile = "3.8.1"
+camino = "*"
+futures = "*"
+sqlx = { version = "*", features = ["postgres", "runtime-tokio"] }
+tempfile = "*"
 fragile-child.path = "../fragile-child"

--- a/crates/fetcher/Cargo.toml
+++ b/crates/fetcher/Cargo.toml
@@ -10,28 +10,28 @@ publish = false
 # See more keys and their definitions at https://doc.rust-lang.org/cargo/reference/manifest.html
 
 [dependencies]
-anyhow = { version = "1.0.75", features = ["backtrace"] }
+anyhow = { version = "*", features = ["backtrace"] }
 camino.workspace = true
-chrono = { version = "0.4.31", features = ["serde"] }
+chrono = { version = "*", features = ["serde"] }
 derive_more.workspace = true
 pr-tracker-fetcher-config = { path = "../fetcher-config" }
-futures = "0.3.29"
-gix = { version = "0.56.0", features = ["revision"] }
-graphql_client = { version = "0.13.0", features = ["reqwest-rustls", "graphql_query_derive"], default-features = false }
-itertools = "0.12.0"
-log = "0.4"
-env_logger = "0.10.1"
+futures = "*"
+gix = { version = "*", features = ["revision"] }
+graphql_client = { version = "*", features = ["reqwest-rustls", "graphql_query_derive"], default-features = false }
+itertools = "*"
+log = "*"
+env_logger = "*"
 pr-tracker-store.workspace = true
-reqwest = { version = "0.11.22", default-features = false, features = ["rustls"] }
+reqwest = { version = "*", default-features = false, features = ["rustls"] }
 serde.workspace = true
-tokio = { version = "1.34.0", features = ["process", "macros", "rt", "rt-multi-thread"] }
+tokio = { version = "*", features = ["process", "macros", "rt", "rt-multi-thread"] }
 util.workspace = true
-wildmatch = { version = "2.3.0", features = ["serde"] }
-sqlx-core = "0.7.3"
-serde_json = "1.0.111"
+wildmatch = { version = "*", features = ["serde"] }
+sqlx-core = "*"
+serde_json = "*"
 confique.workspace = true
 
 [dev-dependencies]
 db-context.workspace = true
-once_cell = "1.19.0"
+once_cell = "*"
 tempfile.workspace = true

--- a/crates/store/Cargo.toml
+++ b/crates/store/Cargo.toml
@@ -12,7 +12,7 @@ publish = false
 
 [dependencies]
 derive_more = { workspace = true, features = ["display"] }
-futures = "0.3.29"
-getset = "0.1.2"
-sqlx = { version = "0.7.3", features = ["postgres", "runtime-tokio"] }
+futures = "*"
+getset = "*"
+sqlx = { version = "*", features = ["postgres", "runtime-tokio"] }
 thiserror.workspace = true

--- a/crates/util/Cargo.toml
+++ b/crates/util/Cargo.toml
@@ -11,6 +11,6 @@ publish = false
 
 [dependencies]
 db-context.workspace = true
-futures = "0.3.29"
-sqlx = { version = "0.7.3", features = ["postgres", "runtime-tokio"] }
-tokio = { version = "1.34.0", features = ["process", "macros", "rt", "rt-multi-thread"] }
+futures = "*"
+sqlx = { version = "*", features = ["postgres", "runtime-tokio"] }
+tokio = { version = "*", features = ["process", "macros", "rt", "rt-multi-thread"] }


### PR DESCRIPTION
The idea here is to let the version specifiers in our Cargo.toml files have more meaning: "*" means "as far as we know, it's ok to upgrade this package". As we discover breaking changes in dependencies, we expect to change some of these "*" into "<=" ranges.