### PR TITLE
build(flake): remove nonxistent crane.nixpkgs override

### DIFF
--- a/flake.nix
+++ b/flake.nix
@@ -2,7 +2,6 @@
   inputs = {
     nixpkgs.url = "github:NixOS/nixpkgs/nixpkgs-unstable";
 
-    crane.inputs.nixpkgs.follows = "nixpkgs";
     crane.url = "github:ipetkov/crane";
     fenix.inputs.nixpkgs.follows = "nixpkgs";
     fenix.url = "github:nix-community/fenix";


### PR DESCRIPTION
We've started getting this warning:

    $ nix flake show
    warning: input 'crane' has an override for a non-existent input 'nixpkgs'
    ...

This started happening because crane recently dropped its dependency on nixpkgs: https://github.com/ipetkov/crane/commit/6f7504ad93304e8ddf29c0b82442f61c03900ccb.