### PR TITLE
feat(flake): NixOS modules have key and _file

### DIFF
--- a/modules/api/nixos-module.nix
+++ b/modules/api/nixos-module.nix
@@ -1,5 +1,6 @@
 {
   mkNixosModuleLib,
+  moduleLocation,
   privateNixosModules,
   ...
 }: {
@@ -15,6 +16,10 @@
 
     cfg = config.services.pr-tracker.api;
   in {
+    # https://github.com/NixOS/nixpkgs/issues/215496
+    key = "${moduleLocation}#api";
+    _file = "${moduleLocation}#api";
+
     imports = [
       privateNixosModules.db
     ];

--- a/modules/fetcher/nixos-module.nix
+++ b/modules/fetcher/nixos-module.nix
@@ -1,5 +1,6 @@
 {
   mkNixosModuleLib,
+  moduleLocation,
   privateNixosModules,
   ...
 }: {
@@ -15,6 +16,10 @@
 
     cfg = config.services.pr-tracker.fetcher;
   in {
+    # https://github.com/NixOS/nixpkgs/issues/215496
+    key = "${moduleLocation}#fetcher";
+    _file = "${moduleLocation}#fetcher";
+
     imports = [
       privateNixosModules.db
     ];


### PR DESCRIPTION
This solves issues with diamond dependencies, and gives better error messages when code fails to evaluate.