### PR TITLE
Eliminate some references

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2486,6 +2486,7 @@ dependencies = [
  "db-context",
  "fragile-child",
  "futures",
+ "getset",
  "poem",
  "pr-tracker-api-config",
  "pr-tracker-store",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -17,6 +17,7 @@ db-context.path = "crates/db-context"
 derive_more = { version = "1.0.0-beta.6", features = ["from", "deref"] }
 fragile-child.path = "crates/fragile-child"
 futures = "*"
+getset = "*"
 gix = { version = "*", features = ["revision"] }
 pr-tracker-store.path = "crates/store"
 serde = "*"

--- a/crates/api/Cargo.toml
+++ b/crates/api/Cargo.toml
@@ -29,4 +29,5 @@ sd-notify = "*"
 [dev-dependencies]
 db-context.workspace = true
 fragile-child.workspace = true
+getset.workspace = true
 tempfile.workspace = true

--- a/crates/api/src/lib.rs
+++ b/crates/api/src/lib.rs
@@ -12,7 +12,7 @@ use pr_tracker_store::{ForPrError, Landing, PrNumberNonPositiveError};
 
 /// # Panics
 /// See implementation.
-pub async fn endpoint<'a>(db_url: &str) -> BoxEndpoint<'a> {
+pub async fn endpoint(db_url: &str) -> BoxEndpoint<'static> {
     let db_pool = PoolOptions::<Postgres>::new()
         .acquire_timeout(Duration::from_secs(5))
         .connect(db_url)

--- a/crates/api/test-util.rs
+++ b/crates/api/test-util.rs
@@ -2,13 +2,12 @@ use db_context::LogDestination;
 use futures::{future::LocalBoxFuture, FutureExt};
 use poem::endpoint::BoxEndpoint;
 
+#[derive(getset::Getters, getset::MutGetters)]
 pub struct TestContext<'a> {
-    // sorry, Rust — definitely in use
-    #[allow(dead_code)]
-    pub db: &'a mut db_context::DatabaseContext,
-    // sorry, Rust — definitely in use
-    #[allow(dead_code)]
-    pub client: poem::test::TestClient<BoxEndpoint<'a>>,
+    #[getset(get = "pub", get_mut = "pub")]
+    db: db_context::DatabaseContext,
+    #[getset(get = "pub")]
+    client: poem::test::TestClient<BoxEndpoint<'a>>,
 }
 
 impl TestContext<'_> {

--- a/crates/api/test-util.rs
+++ b/crates/api/test-util.rs
@@ -3,15 +3,15 @@ use futures::{future::LocalBoxFuture, FutureExt};
 use poem::endpoint::BoxEndpoint;
 
 #[derive(getset::Getters, getset::MutGetters)]
-pub struct TestContext<'a> {
+pub struct TestContext {
     #[getset(get = "pub", get_mut = "pub")]
     db: db_context::DatabaseContext,
     #[getset(get = "pub")]
-    client: poem::test::TestClient<BoxEndpoint<'a>>,
+    client: poem::test::TestClient<BoxEndpoint<'static>>,
 }
 
-impl TestContext<'_> {
-    pub async fn with(test: impl FnOnce(TestContext<'_>) -> LocalBoxFuture<()> + 'static) {
+impl TestContext {
+    pub async fn with(test: impl FnOnce(TestContext) -> LocalBoxFuture<'static, ()> + 'static) {
         db_context::DatabaseContext::with(
             |db_context| {
                 async {

--- a/crates/api/tests/test.rs
+++ b/crates/api/tests/test.rs
@@ -9,7 +9,7 @@ use test_util::TestContext;
 async fn healthcheck_ok() {
     TestContext::with(|ctx| {
         async move {
-            let response = ctx.client.get("/api/v1/healthcheck").send().await;
+            let response = ctx.client().get("/api/v1/healthcheck").send().await;
             response.assert_status_is_ok();
         }
         .boxed()
@@ -19,10 +19,10 @@ async fn healthcheck_ok() {
 
 #[tokio::test]
 async fn healthcheck_not_ok() {
-    TestContext::with(|ctx| {
+    TestContext::with(|mut ctx| {
         async move {
-            ctx.db.kill_db().unwrap();
-            let response = ctx.client.get("/api/v1/healthcheck").send().await;
+            ctx.db_mut().kill_db().unwrap();
+            let response = ctx.client().get("/api/v1/healthcheck").send().await;
             response.assert_status(StatusCode::SERVICE_UNAVAILABLE);
         }
         .boxed()
@@ -34,7 +34,7 @@ async fn healthcheck_not_ok() {
 async fn pr_not_found() {
     TestContext::with(|ctx| {
         async move {
-            let response = ctx.client.get("/api/v1/2134").send().await;
+            let response = ctx.client().get("/api/v1/2134").send().await;
             response.assert_status(StatusCode::NOT_FOUND);
             response.assert_text("Pull request not found.").await;
         }
@@ -47,7 +47,7 @@ async fn pr_not_found() {
 async fn pr_not_landed() {
     TestContext::with(|ctx| {
         async move {
-            let mut connection = ctx.db.connection().await.unwrap();
+            let mut connection = ctx.db().connection().await.unwrap();
 
             pr_tracker_store::Pr {
                 number: 123.try_into().unwrap(),
@@ -57,7 +57,7 @@ async fn pr_not_landed() {
             .await
             .unwrap();
 
-            let response = ctx.client.get("/api/v1/123").send().await;
+            let response = ctx.client().get("/api/v1/123").send().await;
             response.assert_status_is_ok();
             response
                 .assert_json(pr_tracker_api::LandedIn { branches: vec![] })
@@ -72,7 +72,7 @@ async fn pr_not_landed() {
 async fn pr_landed() {
     TestContext::with(|ctx| {
         async move {
-            let connection = &mut ctx.db.connection().await.unwrap();
+            let connection = &mut ctx.db().connection().await.unwrap();
 
             let branch = pr_tracker_store::Branch::get_or_insert(connection, "nixos-unstable")
                 .await
@@ -91,7 +91,7 @@ async fn pr_landed() {
 
             landing.upsert(connection).await.unwrap();
 
-            let response = ctx.client.get("/api/v1/2134").send().await;
+            let response = ctx.client().get("/api/v1/2134").send().await;
             response.assert_status_is_ok();
 
             response

--- a/crates/db-context/src/lib.rs
+++ b/crates/db-context/src/lib.rs
@@ -123,12 +123,10 @@ impl DatabaseContext {
     }
 
     pub async fn with<T>(
-        f: impl FnOnce(&mut Self) -> LocalBoxFuture<T>,
+        f: impl FnOnce(Self) -> LocalBoxFuture<'static, T>,
         log_destination: LogDestination,
     ) -> T {
-        let mut ctx = Self::init(log_destination).await;
-        let t = f(&mut ctx).await;
-        drop(ctx);
-        t
+        let ctx = Self::init(log_destination).await;
+        f(ctx).await
     }
 }

--- a/crates/store/Cargo.toml
+++ b/crates/store/Cargo.toml
@@ -13,6 +13,6 @@ publish = false
 [dependencies]
 derive_more = { workspace = true, features = ["display"] }
 futures.workspace = true
-getset = "*"
+getset.workspace = true
 sqlx = { version = "*", features = ["postgres", "runtime-tokio"] }
 thiserror.workspace = true

--- a/crates/util/src/bin/db-repl.rs
+++ b/crates/util/src/bin/db-repl.rs
@@ -6,7 +6,7 @@ use std::process::{self, Command};
 async fn main() {
     let code = DatabaseContext::with(
         |database_ctx| {
-            async {
+            async move {
                 let pool = database_ctx.pool().await.unwrap();
                 util::migrate(&pool).await.unwrap();
                 let db_url = database_ctx.db_url();

--- a/crates/util/src/bin/sqlx-prepare.rs
+++ b/crates/util/src/bin/sqlx-prepare.rs
@@ -6,7 +6,7 @@ use std::process::Command;
 async fn main() {
     DatabaseContext::with(
         |ctx| {
-            async {
+            async move {
                 let pool = ctx.pool().await.unwrap();
                 util::migrate(&pool).await.unwrap();
 


### PR DESCRIPTION
- **chore: move test contexts rather than borrowing**
- **chore: static lifetime in type of client field of TestContext**
- **refactor: api `fn endpoint` returns a static lifetime**
