### PR TITLE
chore: remove reference to nonexistent git-hooks-nix nixpkgs-stable input

### DIFF
--- a/flake.nix
+++ b/flake.nix
@@ -11,7 +11,6 @@
     flake-parts.url = "github:hercules-ci/flake-parts";
     git-hooks-nix.url = "github:cachix/git-hooks.nix";
     git-hooks-nix.inputs.nixpkgs.follows = "nixpkgs";
-    git-hooks-nix.inputs.nixpkgs-stable.follows = "nixpkgs";
     github-graphql-schema.flake = false;
     github-graphql-schema.url = "github:octokit/graphql-schema";
     nmd.inputs.nixpkgs.follows = "nixpkgs";


### PR DESCRIPTION
`git-hooks-nix` removed this input in
https://github.com/cachix/git-hooks.nix/commit/76a436220ae3fea161c7370c06efa1e55cbb1f00