### PR TITLE
fix: address race condition with migrations

### DIFF
--- a/modules/private-nixos-modules/db.nix
+++ b/modules/private-nixos-modules/db.nix
@@ -98,6 +98,7 @@
             systemd.services.postgresql-setup.postStart = ''
               psql '${cfg.db.name}' -c 'GRANT "${cfg.db.name}" TO "${programCfg.user}"'
               psql '${cfg.db.name}' -c 'ALTER DEFAULT PRIVILEGES FOR ROLE "${programCfg.user}" IN SCHEMA public GRANT ALL PRIVILEGES ON TABLES TO "${cfg.db.name}"'
+              psql '${cfg.db.name}' -c 'ALTER DEFAULT PRIVILEGES FOR ROLE "${programCfg.user}" IN SCHEMA public GRANT ALL PRIVILEGES ON SEQUENCES TO "${cfg.db.name}"'
             '';
           };
         }


### PR DESCRIPTION
Our architecture is a bit strange here: both pr-tracker-api and pr-tracker-fetcher race to apply migrations to the database. We just ran into a situation where pr-tracker-api creates the `branches` table, along with an associated `branches_id_seq` sequence which the pr-tracker-fetcher user did not have access to:

```
pr-tracker=> SELECT schemaname, sequencename, sequenceowner FROM pg_sequences;
 schemaname |  sequencename   | sequenceowner
------------+-----------------+----------------
 public     | branches_id_seq | pr-tracker-api
```

This resulted in pr-tracker-fetcher failing to insert rows into the `branches` table:

```
LOG:  execute sqlx_s_9: SELECT * from github_prs
LOG:  statement: BEGIN
LOG:  execute sqlx_s_10: SELECT * from branches WHERE name = $1
DETAIL:  parameters: $1 = 'master'
LOG:  execute sqlx_s_11: INSERT INTO branches (name) VALUES ($1) RETURNING *
DETAIL:  parameters: $1 = 'master'
ERROR:  permission denied for sequence branches_id_seq
```

I don't know if there are other postgres nouns that we're going to wish we'd granted as well.

Ideally we'd have caught this in our nixos tests, but I don't think any of our nixos tests actually do anything interesting with pr-tracker-fetcher, because that would require talking to github. I've filed https://github.com/molybdenumsoftware/pr-tracker/issues/268 to track that.