### PR TITLE
chore: pass `--auth trust` to initdb in DatabaseContext::init

### DIFF
--- a/crates/db-context/src/lib.rs
+++ b/crates/db-context/src/lib.rs
@@ -69,7 +69,11 @@ impl DatabaseContext {
             }
         }
 
-        let status = initdb.arg(&data_dir).status().unwrap();
+        let status = initdb
+            .arg(&data_dir)
+            .args(["--auth", "trust"])
+            .status()
+            .unwrap();
 
         assert!(status.success());
 


### PR DESCRIPTION
This prevents the following warning:

```
initdb: warning: enabling "trust" authentication for local connections
initdb: hint: You can change this by editing pg_hba.conf or using the option -A, or --auth-local and --auth-host, the next time you run initdb.
```
